### PR TITLE
Enable support for random port assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ stacktrace.log
 target
 web-app
 *.zip
+*.zip.sha1
 .settings
 
 .idea

--- a/TomcatGrailsPlugin.groovy
+++ b/TomcatGrailsPlugin.groovy
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 class TomcatGrailsPlugin {
-    def version = "7.0.42"
+    def version = "7.0.42.1"
     def grailsVersion = "2.3 > *"
     def scopes = [excludes: 'war']
     def author = "Graeme Rocher"

--- a/src/groovy/org/grails/plugins/tomcat/fork/TomcatDevelopmentRunner.groovy
+++ b/src/groovy/org/grails/plugins/tomcat/fork/TomcatDevelopmentRunner.groovy
@@ -6,6 +6,7 @@ import org.apache.catalina.startup.Tomcat
 import org.codehaus.groovy.grails.io.support.Resource
 import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
 import org.grails.plugins.tomcat.InlineExplodedTomcatServer
+import org.grails.plugins.tomcat.TomcatServer
 
 /**
  * @author Graeme Rocher
@@ -82,7 +83,8 @@ class TomcatDevelopmentRunner extends InlineExplodedTomcatServer {
     @Override
     void stop() {
         try {
-            new URL("http://${currentHost}:${currentPort+ 1}").text
+            def killSwitchOffset = TomcatServer.isRandomPortSupported(buildSettings) ? -1 : 1
+            new URL("http://${currentHost}:${currentPort + killSwitchOffset}").text
         } catch(e) {
             // ignore
         }

--- a/src/groovy/org/grails/plugins/tomcat/fork/TomcatExecutionContext.groovy
+++ b/src/groovy/org/grails/plugins/tomcat/fork/TomcatExecutionContext.groovy
@@ -37,6 +37,7 @@ class TomcatExecutionContext extends ExecutionContext {
     int port = EmbeddableServer.DEFAULT_PORT
     int securePort
     String warPath
+    String completedContextPath
 
     @Override
     protected List<File> buildMinimalIsolatedClasspath(BuildSettings buildSettings) {


### PR DESCRIPTION
:warning: Looking for some feedback on the content of this pull request before it is merged. Specifically in how the 'killSwitch' port is being determined.

The issue is that if a user sets both http and https ports to be 0, then they will be assigned sequential ports by the OS (most likely) - for example `grails run-app -Dserver.port=0 -Dserver.port.https=0` results in Grails binding HTTP to 54376 and HTTPS to 54377. This stops the kill switch thread from binding to the HTTP port + 1.
To handle this and provide for backwards compatibility, I've only enabled the ability to assign the ports to 0 starting with Grails 2.3.2 and beyond (use the buildSettings.grailsVersion to figure that out). Otherwise, the plugin will behave as it originally did (assigning -Dserver.port=0 results in using the DEFAULT_PORT, 8080)

These changes will also require some small changes to Grails-Core. This commit summarizes those changes (https://github.com/johnrengelman/grails-core/commit/78ced9d6b8aa67eccc35fd23be1943326f0d1896)
