### PR TITLE
Added "stop" and "start" to list of available commands....

### DIFF
--- a/TomcatGrailsPlugin.groovy
+++ b/TomcatGrailsPlugin.groovy
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 class TomcatGrailsPlugin {
-    def version = "7.0.55"
+    def version = "7.0.55.1"
     def grailsVersion = "2.3 > *"
     def scopes = [excludes: 'war']
     def author = "Graeme Rocher"

--- a/application.properties
+++ b/application.properties
@@ -1,3 +1,3 @@
-app.grails.version=2.3.8
+app.grails.version=2.3.11
 app.name=tomcat-plugin
 

--- a/scripts/Tomcat.groovy
+++ b/scripts/Tomcat.groovy
@@ -7,12 +7,16 @@ includeTargets << grailsScript("_GrailsWar")
 ant.taskdef(name: "deploy",   classname: "org.apache.catalina.ant.DeployTask")
 ant.taskdef(name: "list",     classname: "org.apache.catalina.ant.ListTask")
 ant.taskdef(name: "undeploy", classname: "org.apache.catalina.ant.UndeployTask")
+ant.taskdef(name: "start", classname: "org.apache.catalina.ant.StartTask")
+ant.taskdef(name: "stop", classname: "org.apache.catalina.ant.StopTask")
 
 target(tomcat: '''\
 Script used to interact with remote Tomcat. The following subcommands are available:
 
 grails tomcat deploy - Deploy to a tomcat server
 grails tomcat undeploy - Undeploy from a tomcat server
+grails tomcat stop - Stop the tomcat webapp context
+grails tomcat start - Start the tomcat webapp context
 ''') {
 
     depends(parseArguments, compile, createConfig)
@@ -46,6 +50,19 @@ NOTE: If you experience a classloading error during undeployment you need to tak
 See http://tomcat.apache.org/tomcat-7.0-doc/config/systemprops.html for more information
 '''
             undeploy(url: url, path: serverContextPath, username: user, password: pass)
+            break
+
+        case 'start':
+            configureServerContextPath()
+            println "Starting application $serverContextPath in Tomcat"
+            start(url: url, path: serverContextPath, username: user, password: pass)
+            break
+
+        case 'stop':
+            configureServerContextPath()
+            println "Stopping application $serverContextPath in Tomcat"
+            stop(url: url, path: serverContextPath, username: user, password: pass)
+            break
     }
 }
 


### PR DESCRIPTION
Hi,

This fork introduces 'tomcat start' and 'tomcat stop', following the pattern used by the other, existing tasks.

I found that these commands only start and stop the webapp context if it's already deployed; they don't stop and start the container instance. I introduced this fork as an experiment to see if I could eliminate PermGen space errors in our build. Because the instance is not restarted, the stop and start commands didn't fix the issue.

I thought I would submit the changes anyway, in case other people might find it useful. I smoke tested the commands and they seem to work normally.

I updated the plugin to the latest minor version of grails (2.3.11). Feel free to drop this change if it causes some kind of issue. I didn't see any problems in my testing.

I wasn't sure what to do about the plugin version, since it seems to correspond to the tomcat version and the tomcat version didn't change. I added ".1" to the end of the version number for testing but I was worried that it might not be the correct thing to do.

Thanks in advance for your feedback!
-Russ
