### PR TITLE
fix for GPTOMCAT-24

### DIFF
--- a/src/groovy/org/grails/plugins/tomcat/TomcatServer.groovy
+++ b/src/groovy/org/grails/plugins/tomcat/TomcatServer.groovy
@@ -207,11 +207,16 @@ abstract class TomcatServer implements EmbeddableServer {
 
 	protected getKeyToolClass() {
 		try {
-			Class.forName 'sun.security.tools.KeyTool'
+			Class.forName 'sun.security.tools.KeyTool.Main'
 		}
-		catch (ClassNotFoundException e) {
-			// no try/catch for this one, if neither is found let it fail
-			Class.forName 'com.ibm.crypto.tools.KeyTool'
-		}
+		catch (ClassNotFoundException e1) {
+      try {
+        Class.forName 'sun.security.tools.KeyTool'
+      }
+      catch (ClassNotFoundException e2) {
+        // no try/catch for this one, if neither is found let it fail
+        Class.forName 'com.ibm.crypto.tools.KeyTool'
+      }
+    }
 	}
 }


### PR DESCRIPTION
Extended the getKeyToolClass method to work with JDK 8 with fallback support for older versions.